### PR TITLE
Improve Metabase automation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,3 +19,5 @@ MB_PORT=3000
 MB_JAVA_TIMEZONE=America/Argentina/Buenos_Aires
 MB_ADMIN_EMAIL=admin@domain.com
 MB_ADMIN_PASSWORD=password
+MB_ADMIN_FIRST_NAME=Admin
+MB_ADMIN_LAST_NAME=User

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Based on official docker images for [PostgreSQL] and [Metabase].
 ## Usage
 
 - Clone this repository.
+
 - Copy `.env.sample` to `.env` and adjust the variables.
-- Start services locally using Docker Compose.
+- Use the provided script to reset and start the project from scratch:
 
   ```shell
-  $ docker compose up
+  $ ./restart_project.sh
   ```
+
+This script removes any previous containers and volumes before running `docker compose up` internally.
 
 Metabase can connect to host (`host.docker.internal`) from static IP `172.16.200.30`,
 (static IP can be used for authentication. e.g. in `pg_hba.conf`)

--- a/add_mydata_to_metabase.sh
+++ b/add_mydata_to_metabase.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
+set -eo pipefail
+
+# Directorio del script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Cargar variables del archivo .env
 set -a
-source .env
+source "$SCRIPT_DIR/.env"
 set +a
 
 # Espera a que Metabase esté disponible
@@ -10,15 +15,32 @@ until curl -s http://metabase:3000/api/health | grep -q '"ok":true'; do
   sleep 5
 done
 
+# Verificar si la configuración inicial fue completada
+SETUP_TOKEN=$(curl -s http://metabase:3000/api/session/properties | jq -r '."setup-token"')
+if [ "$SETUP_TOKEN" != "null" ]; then
+  echo "Realizando configuración inicial de Metabase..."
+  curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -d "{\"token\": \"$SETUP_TOKEN\", \"user\": {\"email\": \"$MB_ADMIN_EMAIL\", \"password\": \"$MB_ADMIN_PASSWORD\", \"first_name\": \"$MB_ADMIN_FIRST_NAME\", \"last_name\": \"$MB_ADMIN_LAST_NAME\"}, \"prefs\": {\"site_name\": \"Metabase\"}}" \
+    http://metabase:3000/api/setup
+fi
+
 # Autenticación en Metabase
 MB_SESSION=$(curl -s -X POST \
   -H "Content-Type: application/json" \
   -d "{\"username\": \"$MB_ADMIN_EMAIL\", \"password\": \"$MB_ADMIN_PASSWORD\"}" \
   http://metabase:3000/api/session | jq -r .id)
 
-# Crear la conexión a la base de datos MyData
-curl -s -X POST \
-  -H "Content-Type: application/json" \
-  -H "X-Metabase-Session: $MB_SESSION" \
-  -d "{\n    \"name\": \"$MYDATA_DB_NAME\",\n    \"engine\": \"postgres\",\n    \"details\": {\n      \"host\": \"db\",\n      \"port\": 5432,\n      \"dbname\": \"$MYDATA_DB_NAME\",\n      \"user\": \"$MYDATA_DB_USER\",\n      \"password\": \"$MYDATA_DB_PASSWORD\"\n    }\n  }" \
-  http://metabase:3000/api/database
+# Crear la conexión a la base de datos MyData si no existe
+EXISTING_DB=$(curl -s -H "X-Metabase-Session: $MB_SESSION" \
+  http://metabase:3000/api/database | jq -r --arg name "$MYDATA_DB_NAME" '.[] | select(.name == $name) | .id')
+if [ -z "$EXISTING_DB" ]; then
+  echo "Creando conexión a la base de datos $MYDATA_DB_NAME..."
+  curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-Metabase-Session: $MB_SESSION" \
+    -d "{\n    \"name\": \"$MYDATA_DB_NAME\",\n    \"engine\": \"postgres\",\n    \"details\": {\n      \"host\": \"db\",\n      \"port\": 5432,\n      \"dbname\": \"$MYDATA_DB_NAME\",\n      \"user\": \"$MYDATA_DB_USER\",\n      \"password\": \"$MYDATA_DB_PASSWORD\"\n    }\n  }" \
+    http://metabase:3000/api/database
+else
+  echo "La conexión $MYDATA_DB_NAME ya existe (id $EXISTING_DB)"
+fi

--- a/restart_project.ps1
+++ b/restart_project.ps1
@@ -3,10 +3,10 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 Set-Location $scriptDir
 
 Write-Host "Deteniendo y eliminando contenedores..."
-docker-compose down -v
+docker compose down -v
 
 Write-Host "Eliminando imágenes huérfanas..."
 docker image prune -f
 
 Write-Host "Iniciando el proyecto desde cero..."
-docker-compose up --build
+docker compose up --build

--- a/restart_project.sh
+++ b/restart_project.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Script para limpiar y reiniciar el proyecto desde cualquier ubicación (Linux/Mac)
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit
 
 echo "Deteniendo y eliminando contenedores..."
-docker-compose down -v
+docker compose down -v
 
 echo "Eliminando imágenes huérfanas..."
 docker image prune -f
 
 echo "Iniciando el proyecto desde cero..."
-docker-compose up --build
+docker compose up --build


### PR DESCRIPTION
## Summary
- add new admin fields to `.env.sample`
- improve setup script to automate initial Metabase configuration
- use `docker compose` in restart scripts and fail fast if `cd` fails
- mention restart script in README

## Testing
- `shellcheck -e SC1091 add_mydata_to_metabase.sh`
- `shellcheck restart_project.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fe89b7088832c93b1c0ffb224b9a2