### PR TITLE
Fix init-metabase user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
 
   init-metabase:
     image: curlimages/curl:latest
+    user: root
     depends_on:
       - metabase
     entrypoint: ["sh", "-c", "apk add --no-cache bash jq && bash /scripts/add_mydata_to_metabase.sh"]


### PR DESCRIPTION
## Summary
- run the init-metabase container as root

## Testing
- `docker-compose up --build -d` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687ff364ef78832c88af5827d10daa10