### PR TITLE
Fix Metabase health check condition

### DIFF
--- a/add_mydata_to_metabase.sh
+++ b/add_mydata_to_metabase.sh
@@ -10,7 +10,7 @@ source "$SCRIPT_DIR/.env"
 set +a
 
 # Espera a que Metabase esté disponible
-until curl -s http://metabase:3000/api/health | grep -q '"ok":true'; do
+until curl -s http://metabase:3000/api/health | jq -e '.status == "ok"' >/dev/null; do
   echo "Esperando a que Metabase esté listo..."
   sleep 5
 done


### PR DESCRIPTION
## Summary
- fix health check in add_mydata_to_metabase script

## Testing
- `bash -n add_mydata_to_metabase.sh`
- `sudo apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ff77d5eb0832cabe2bebea9f0d27e