### PR TITLE
Fix init script for sh compatibility

### DIFF
--- a/add_mydata_to_metabase.sh
+++ b/add_mydata_to_metabase.sh
@@ -1,12 +1,12 @@
-#!/usr/bin/env bash
-set -eo pipefail
+#!/usr/bin/env sh
+set -e
 
 # Directorio del script
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Cargar variables del archivo .env
 set -a
-source "$SCRIPT_DIR/.env"
+. "$SCRIPT_DIR/.env"
 set +a
 
 # Espera a que Metabase esté disponible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     user: root
     depends_on:
       - metabase
-    entrypoint: ["sh", "-c", "apk add --no-cache bash jq && bash /scripts/add_mydata_to_metabase.sh"]
+    entrypoint: ["sh", "-c", "apk add --no-cache jq && sh /scripts/add_mydata_to_metabase.sh"]
     volumes:
       - ./add_mydata_to_metabase.sh:/scripts/add_mydata_to_metabase.sh:ro
       - ./.env:/scripts/.env:ro


### PR DESCRIPTION
## Summary
- make `add_mydata_to_metabase.sh` POSIX sh compatible
- update `docker-compose.yml` to run the script with `/bin/sh` only

## Testing
- `bash -n add_mydata_to_metabase.sh`
- `sh -n add_mydata_to_metabase.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ffefc7f5c832c8b3ef1015c00fcbf