### PR TITLE
Fix line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- ensure `.sh` files use LF line endings so scripts run correctly on Alpine

## Testing
- `shellcheck add_mydata_to_metabase.sh` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68800303a3b0832c92b3f4ba03b852bf