### PR TITLE
Fix .env quoting for busybox

### DIFF
--- a/.env
+++ b/.env
@@ -1,21 +1,23 @@
 ## PostgreSQL admin user
 POSTGRES_DB=postgres
 POSTGRES_USER=admin
-POSTGRES_PASSWORD=$pStgR3Z
+POSTGRES_PASSWORD='$pStgR3Z'
 DB_DATA_DIR=/var/lib/postgresql/data
 
 ## Metabase database and user
 METABASE_DB_NAME=metabase
 METABASE_DB_USER=metabase_user
-METABASE_DB_PASSWORD=?pZwM3T4$
+METABASE_DB_PASSWORD='?pZwM3T4$'
 
 ## MyData database and user
 MYDATA_DB_NAME=MyData
 MYDATA_DB_USER=mydata_user
-MYDATA_DB_PASSWORD=mYd4t?pzW
+MYDATA_DB_PASSWORD='mYd4t?pzW'
 
 ## Metabase environment
 MB_PORT=3000
 MB_JAVA_TIMEZONE=America/Argentina/Buenos_Aires
 MB_ADMIN_EMAIL=admin@analyticsplatform.com
-MB_ADMIN_PASSWORD=Ap_7?2#jPd
+MB_ADMIN_PASSWORD='Ap_7?2#jPd'
+MB_ADMIN_FIRST_NAME=Admin
+MB_ADMIN_LAST_NAME=User


### PR DESCRIPTION
## Summary
- ensure special characters in `.env` don't get expanded when sourced
- include admin first and last name settings

## Testing
- `dash add_mydata_to_metabase.sh` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6880084ce120832c9d73241092e74658