### PR TITLE
Fix env loading with CRLF

### DIFF
--- a/add_mydata_to_metabase.sh
+++ b/add_mydata_to_metabase.sh
@@ -5,8 +5,13 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Cargar variables del archivo .env
+ENV_FILE="$SCRIPT_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+  # Elimina retornos de carro por si el archivo usa formato Windows
+  tr -d '\r' < "$ENV_FILE" > /tmp/.env && ENV_FILE=/tmp/.env
+fi
 set -a
-. "$SCRIPT_DIR/.env"
+. "$ENV_FILE"
 set +a
 
 # Espera a que Metabase esté disponible


### PR DESCRIPTION
## Summary
- sanitize `.env` when loading in the add_mydata_to_metabase script

## Testing
- `sh -n add_mydata_to_metabase.sh`

------
https://chatgpt.com/codex/tasks/task_e_6880099c8bc4832c97b178311128aa8b