### PR TITLE
Fix jq filter for database lookup

### DIFF
--- a/add_mydata_to_metabase.sh
+++ b/add_mydata_to_metabase.sh
@@ -38,7 +38,7 @@ MB_SESSION=$(curl -s -X POST \
 
 # Crear la conexión a la base de datos MyData si no existe
 EXISTING_DB=$(curl -s -H "X-Metabase-Session: $MB_SESSION" \
-  http://metabase:3000/api/database | jq -r --arg name "$MYDATA_DB_NAME" '.[] | select(.name == $name) | .id')
+  http://metabase:3000/api/database | jq -r --arg name "$MYDATA_DB_NAME" '.data[]? | select(.name == $name) | .id')
 if [ -z "$EXISTING_DB" ]; then
   echo "Creando conexión a la base de datos $MYDATA_DB_NAME..."
   curl -s -X POST \


### PR DESCRIPTION
## Summary
- correct jq filter to parse Metabase's `/api/database` response

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68800c0e95cc832cb0407d1a15103100